### PR TITLE
fix Util.getRealUrl method

### DIFF
--- a/src/jquery.pjax.js
+++ b/src/jquery.pjax.js
@@ -19,7 +19,7 @@
 		// 获取URL不带hash的部分,切去掉pjax=true部分
 		getRealUrl : function(url) {
 			url = (url || '').replace(/\#.*?$/, '');
-			url = url.replace('?pjax=true', '').replace('&pjax=true', '');
+			url = url.replace('?pjax=true&', '?').replace('?pjax=true', '').replace('&pjax=true', '');
 			return url;
 		},
 		// 获取url的hash部分

--- a/src/kissy.pjax.js
+++ b/src/kissy.pjax.js
@@ -19,7 +19,7 @@ KISSY.add('pjax', function (S, DOM, Node, Event, Ajax) {
         // 获取URL不带hash的部分,且去掉pjax=true部分
         getRealUrl : function(url) {
             url = (url || '').replace(/\#.*?$/, '');
-            url = url.replace('?pjax=true', '').replace('&pjax=true', '');
+            url = url.replace('?pjax=true&', '?').replace('?pjax=true', '').replace('&pjax=true', '');
             return url;
         },
         // 获取url的hash部分

--- a/src/qwrap.pjax.js
+++ b/src/qwrap.pjax.js
@@ -27,7 +27,7 @@
 		// 获取URL不带hash的部分,切去掉pjax=true部分
 		getRealUrl : function(url) {
 			url = (url || '').replace(/\#.*?$/, '');
-			url = url.replace('?pjax=true', '').replace('&pjax=true', '');
+			url = url.replace('?pjax=true&', '?').replace('?pjax=true', '').replace('&pjax=true', '');
 			return url;
 		},
 		// 获取url的hash部分


### PR DESCRIPTION
`Util.getRealUrl` 需要处理的 url 应该有三种情况：
1. `pjax=true` 是多个参数中的第一个
2. `pjax=true` 是唯一参数
3. `pjax=true` 不是第一个参数

其中情况 1 被漏掉了。当传入符合情况 1 的 url 时将得到错误的结果。
